### PR TITLE
feat: support source code only mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ChangeLog
 
+## v0.16.0~5 - 2024-06-19
+
+* Support source code only mode. enable `TINYUSB_SOURCE_CODE_ONLY` (disable by default) to not build as static library. This is useful for projects that want to include tinyusb source code directly in their project.
+
 ## v0.16.0~4 - 2024-05-09
 
 * Temporary merge https://github.com/hathach/tinyusb/pull/2656 for uvc frame based

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,24 +1,60 @@
-idf_component_register(SRCS "src/tusb.c" "src/common/tusb_fifo.c"
-                    INCLUDE_DIRS "." "src"
-                    REQUIRES freertos soc)
-
-set(DCD_DRIVER_SRC "")
-
 if(CONFIG_USING_SYNOPSYS_DWC2_DRIVER)
 set(DCD_DRIVER_SRC synopsys/dwc2/dcd_dwc2.c)
-else()
+else() # CONFIG_USING_ESP32_DCD_DRIVER
 if(IDF_TARGET STREQUAL "esp32p4")
 # we only support DWC2 for esp32p4
 message(WARNING "Only DWC2 driver is supported for esp32p4")
 set(DCD_DRIVER_SRC synopsys/dwc2/dcd_dwc2.c)
-else()
+else() # esp32s2, esp32s3
 set(DCD_DRIVER_SRC espressif/esp32sx/dcd_esp32sx.c)
-endif()
+endif() # esp32p4
+endif() # CONFIG_USING_SYNOPSYS_DWC2_DRIVER
+set(DCD_CORE_SRCS
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/tusb.c"
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/common/tusb_fifo.c"
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/device/usbd.c"
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/device/usbd_control.c"
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/portable/${DCD_DRIVER_SRC}"
+)
+set(DCD_CORE_INCLUDES
+  "${CMAKE_CURRENT_SOURCE_DIR}"
+  "${CMAKE_CURRENT_SOURCE_DIR}/src"
+)
+
+set(TUSB_COMPILE_OPTIONS 
+  "-Wno-format"
+  "-DCFG_TUSB_OS=OPT_OS_FREERTOS"
+)
+
+if(IDF_TARGET STREQUAL "esp32s2")
+  list(APPEND TUSB_COMPILE_OPTIONS "-DCFG_TUSB_MCU=OPT_MCU_ESP32S2")
+elseif(IDF_TARGET STREQUAL "esp32s3")
+  list(APPEND TUSB_COMPILE_OPTIONS "-DCFG_TUSB_MCU=OPT_MCU_ESP32S3")
+elseif(IDF_TARGET STREQUAL "esp32p4")
+  list(APPEND TUSB_COMPILE_OPTIONS "-DCFG_TUSB_MCU=OPT_MCU_ESP32P4")
+else()
+  message(FATAL_ERROR "${IDF_TARGET} not supported by tinyusb")
 endif()
 
+if(CONFIG_TINYUSB_SOURCE_CODE_ONLY)
+set(SRCS "")
+set(INCLUDES "")
+else()
+set(SRCS ${DCD_CORE_SRCS})
+set(INCLUDES ${DCD_CORE_INCLUDES})
+endif()
+
+idf_component_register(SRCS ${SRCS}
+                    INCLUDE_DIRS ${INCLUDES}
+                    REQUIRES freertos soc)
+
+idf_component_set_property(${COMPONENT_NAME} DCD_CORE_INCLUDES "${DCD_CORE_INCLUDES}")
+idf_component_set_property(${COMPONENT_NAME} DCD_CORE_SRCS "${DCD_CORE_SRCS}")
+idf_component_set_property(${COMPONENT_NAME} TUSB_COMPILE_OPTIONS "${TUSB_COMPILE_OPTIONS}")
+
+if(NOT CONFIG_TINYUSB_SOURCE_CODE_ONLY)
+# build all class drivers
 target_sources(${COMPONENT_LIB} PRIVATE
-  "src/device/usbd.c"
-  "src/device/usbd_control.c"
   "src/class/audio/audio_device.c"
   "src/class/bth/bth_device.c"
   "src/class/cdc/cdc_device.c"
@@ -32,23 +68,10 @@ target_sources(${COMPONENT_LIB} PRIVATE
   "src/class/usbtmc/usbtmc_device.c"
   "src/class/vendor/vendor_device.c"
   "src/class/video/video_device.c"
-  "src/portable/${DCD_DRIVER_SRC}"
 )
 
 target_compile_options(${COMPONENT_LIB} PUBLIC
-  "-Wno-format"
-  "-DCFG_TUSB_OS=OPT_OS_FREERTOS"
+  ${TUSB_COMPILE_OPTIONS}
 )
 
-if(IDF_TARGET STREQUAL "esp32s2")
-  target_compile_options(${COMPONENT_LIB} PUBLIC
-    "-DCFG_TUSB_MCU=OPT_MCU_ESP32S2")
-elseif(IDF_TARGET STREQUAL "esp32s3")
-  target_compile_options(${COMPONENT_LIB} PUBLIC
-    "-DCFG_TUSB_MCU=OPT_MCU_ESP32S3")
-elseif(IDF_TARGET STREQUAL "esp32p4")
-  target_compile_options(${COMPONENT_LIB} PUBLIC
-    "-DCFG_TUSB_MCU=OPT_MCU_ESP32P4")
-else()
-  message(FATAL_ERROR "${IDF_TARGET} not supported by tinyusb")
-endif()
+endif() # CONFIG_TINYUSB_SOURCE_CODE_ONLY 

--- a/Kconfig
+++ b/Kconfig
@@ -1,5 +1,10 @@
 menu "TinyUSB soucre"
 
+    config TINYUSB_SOURCE_CODE_ONLY
+        bool "Using tinyusb source code only"
+        default n
+        help
+            "Select if you just use the source code, not build as a library"
     config USING_SYNOPSYS_DWC2_DRIVER
         bool "Using synopsys dwc2 driver, otherwise using esp32sx dcd driver"
         default y

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ For more information about TinyUSB, please refer https://docs.tinyusb.org
 |0.16.0~1| Dec 22, 2023 [Tag 0.16.0](https://github.com/hathach/tinyusb/commit/1eb6ce784ca9b8acbbe43dba9f1d9c26c2e80eb0)|
 |0.16.0~2| Mar 7, 2024 [a0e5626b](https://github.com/hathach/tinyusb/commit/a0e5626bc50d484a23f33000c48082179f0cc2dd)|
 |0.16.0~3| May 9, 2024 [a0e5626b](https://github.com/hathach/tinyusb/commit/a0e5626bc50d484a23f33000c48082179f0cc2dd)|
-|0.16.0~3| May 9, 2024 [a0e5626b](https://github.com/hathach/tinyusb/commit/a0e5626bc50d484a23f33000c48082179f0cc2dd)|
 |0.16.0~4| May 22, 2024 [a0e5626b](https://github.com/hathach/tinyusb/commit/a0e5626bc50d484a23f33000c48082179f0cc2dd)|
+|0.16.0~5| Jun 19, 2024 [a0e5626b](https://github.com/hathach/tinyusb/commit/a0e5626bc50d484a23f33000c48082179f0cc2dd)|
 
 ## Feature
 

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.16.0~4"
+version: "0.16.0~5"
 targets:
   - esp32s2
   - esp32s3


### PR DESCRIPTION
You can add `tinyusb_src` component as source code now (by enable `Using tinyusb source code only` in menuconfig), without compiling it as a library.

It's useful for projects that want to include tinyusb source code directly in their project.

* You can get the dcd core sources, include paths, and compile options using:

```cmake
idf_component_get_property(DCD_CORE_INCLUDES leeebo__tinyusb_src DCD_CORE_INCLUDES)
idf_component_get_property(DCD_CORE_SRCS leeebo__tinyusb_src DCD_CORE_SRCS)
idf_component_get_property(TUSB_COMPILE_OPTIONS leeebo__tinyusb_src TUSB_COMPILE_OPTIONS)

#.....

target_compile_options(${COMPONENT_LIB} PUBLIC
    ${TUSB_COMPILE_OPTIONS}
)
```

* Other class drivers should be added based on your needs:

```cmake
idf_component_get_property(TUSB_PATH leeebo__tinyusb_src COMPONENT_DIR)

set(src_tusb
    "${DCD_CORE_SRCS}"
    "${TUSB_PATH}/src/class/cdc/cdc_device.c"
    "${TUSB_PATH}/src/class/msc/msc_device.c"
    )

idf_component_register(
                    SRCS
                    ${src_tusb}
                    INCLUDE_DIRS "." ${DCD_CORE_INCLUDES})
```
